### PR TITLE
Exclude signatures from external dependencies

### DIFF
--- a/src/pom.xml
+++ b/src/pom.xml
@@ -30,6 +30,16 @@
 						<configuration>
 							<finalName>miele-to-mqtt-gw</finalName>
 							<shadedArtifactAttached>true</shadedArtifactAttached>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/*.SF</exclude>
+										<exclude>META-INF/*.DSA</exclude>
+										<exclude>META-INF/*.RSA</exclude>
+									</excludes>
+								</filter>
+							</filters>
 							<transformers>
 								<transformer implementation="org.apache.maven.plugins.shade.resource.ManifestResourceTransformer">
 									<mainClass>de.rnd7.mieletomqtt.Main</mainClass>


### PR DESCRIPTION
Fix java.lang.SecurityException on jar starting. Hopes to fix the issue #25 